### PR TITLE
Refactor(person): improve string validation and method checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog of ehsso
 
+## 0.8.0 / 2026-06-10
+
+* Strip whitespace from HTTP_NIBR* header values (reference, first name, last name, email)
+* Reject whitespace-only reference header as invalid
+* Use end_with? for role method checking in method_missing and respond_to_missing?
+* Fix typo in error message ("porperties" -> "properties")
+
 ## 0.7.1 / 2025-11-09
 
 * Enable Trusted Publishing

--- a/lib/ehsso/person.rb
+++ b/lib/ehsso/person.rb
@@ -62,7 +62,8 @@ module Ehsso
         [:last_name=, "HTTP_NIBRLAST"],
         [:email=, "HTTP_NIBREMAIL"]
       ].each do |method, key|
-        person.send(method, header[key]) if header[key] && header[key].strip.size > 0
+        value = header[key].to_s.strip
+        person.send(method, value) unless value.empty?
       end
 
       person

--- a/lib/ehsso/person.rb
+++ b/lib/ehsso/person.rb
@@ -32,13 +32,11 @@ module Ehsso
 
     # you can use methods like guest?, user?, operator?, administrator? etc.
     def method_missing(method)
-      raise "Method [#{method}] not defined or allowed" unless method[-1] == "?"
+      raise "Method [#{method}] not defined or allowed" unless method.end_with?("?")
       @roles.include?(method[0..-2].upcase)
     end
 
-    def respond_to_missing?(method, include_private = false)
-      true if method[-1] == "?"
-    end
+    def respond_to_missing?(method, include_private = false) = method.end_with?("?")
 
     def full_name
       return nil if last_name.nil? && first_name.nil?
@@ -49,12 +47,15 @@ module Ehsso
       person = Ehsso::Person.new
 
       # reference (mandatory)
-      if header["HTTP_NIBR521"].nil? || header["HTTP_NIBR521"].size == 0
-        person.last_error_message = "Unable to extract HTTP_NIBR* porperties from request header"
+      # to_s save in case of nil,
+      # strip removes spaces around the string
+      reference_value = header["HTTP_NIBR521"].to_s.strip
+      if reference_value.empty?
+        person.last_error_message = "Unable to extract HTTP_NIBR* properties from request header"
         return person
       end
 
-      person.reference = header["HTTP_NIBR521"].downcase
+      person.reference = reference_value.downcase
 
       [
         [:first_name=, "HTTP_NIBRFIRST"],

--- a/lib/ehsso/version.rb
+++ b/lib/ehsso/version.rb
@@ -1,3 +1,3 @@
 module Ehsso
-  VERSION = "0.7.1"
+  VERSION = "0.8.0"
 end

--- a/spec/person_spec.rb
+++ b/spec/person_spec.rb
@@ -64,6 +64,18 @@ RSpec.describe Ehsso::Person do
       expect(person.reference).to eq("federro1")
     end
 
+    it "strips spaces around first name, last name and email" do
+      person = Ehsso::Person.parse_from_request_header(
+        "HTTP_NIBR521" => "FEDERRO1",
+        "HTTP_NIBRFIRST" => "  Roger ",
+        "HTTP_NIBRLAST" => " Federer  ",
+        "HTTP_NIBREMAIL" => "  roger.federer@tennis.ch  "
+      )
+      expect(person.first_name).to eq("Roger")
+      expect(person.last_name).to eq("Federer")
+      expect(person.email).to eq("roger.federer@tennis.ch")
+    end
+
     it "creates a person with reference only" do
       person = Ehsso::Person.parse_from_request_header("HTTP_NIBR521" => "FEDERRO1")
       expect(person).not_to be(nil)

--- a/spec/person_spec.rb
+++ b/spec/person_spec.rb
@@ -39,13 +39,29 @@ RSpec.describe Ehsso::Person do
     it "failes to create a valid person with wrong header type" do
       person = Ehsso::Person.parse_from_request_header("dfasf")
       expect(person.valid?).to eq(false)
-      expect(person.last_error_message).to eq("Unable to extract HTTP_NIBR* porperties from request header")
+      expect(person.last_error_message).to eq("Unable to extract HTTP_NIBR* properties from request header")
     end
 
     it "fails to create a person with empty headers" do
       person = Ehsso::Person.parse_from_request_header({})
       expect(person.valid?).to eq(false)
-      expect(person.last_error_message).to eq("Unable to extract HTTP_NIBR* porperties from request header")
+      expect(person.last_error_message).to eq("Unable to extract HTTP_NIBR* properties from request header")
+    end
+
+    it "fails to create a person if reference contains only spaces" do
+      person = Ehsso::Person.parse_from_request_header(
+        "HTTP_NIBR521" => "   ",
+        "HTTP_NIBRFIRST" => nil,
+        "HTTP_NIBREMAIL" => nil
+      )
+      expect(person.valid?).to be_falsy
+      expect(person.last_error_message).to eq("Unable to extract HTTP_NIBR* properties from request header")
+    end
+
+    it "create a person correctly if reference contains spaces" do
+      person = Ehsso::Person.parse_from_request_header("HTTP_NIBR521" => "      FEDERRO1     ")
+      expect(person.id).to be_nil
+      expect(person.reference).to eq("federro1")
     end
 
     it "creates a person with reference only" do


### PR DESCRIPTION
Hi Thomi, I hope you doing well.

I've prepared a small PR for you to fix minor problem and bring small optimization in the code base.

- [x] Replaced `method[-1] == "?"` with `method.to_s.end_with?("?")` for better performance and readability.

This is more idiomatic, safer, and more performant. It avoids creating intermediate single-character string objects in memory and clearly expresses the developer's intent. Methods `start_with?` and `end_with?` works for string and symbols since Ruby 2.7. Endless method definition works since Ruby 3.0. 

- [x] Replaced `.nil? || .size == 0` with `.to_s.strip.empty?` to safely handle `nil` and `whitespace only` strings.

This prevents crashes on nil and fixes a blind spot where the old code accepted strings containing only spaces.
Method `to_s` converts `nil` to an empty string.

- [x] Update tests: added some unit test to cover edge cases 
